### PR TITLE
Honor browser color schemes for backgrounds

### DIFF
--- a/site/account.html
+++ b/site/account.html
@@ -10,8 +10,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .account-address {
       word-break: break-all;

--- a/site/asset.html
+++ b/site/asset.html
@@ -10,8 +10,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .is-mono {
       font-family: monospace;

--- a/site/index.html
+++ b/site/index.html
@@ -10,8 +10,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .hero {
       min-height: 100vh;

--- a/site/offer.html
+++ b/site/offer.html
@@ -9,8 +9,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .section {
       padding-top: 1.5rem;

--- a/site/offers.html
+++ b/site/offers.html
@@ -9,8 +9,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .section {
       padding-top: 1.5rem;

--- a/site/operation.html
+++ b/site/operation.html
@@ -9,8 +9,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .section {
       padding-top: 1.5rem;

--- a/site/operations.html
+++ b/site/operations.html
@@ -9,8 +9,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .section {
       padding-top: 1.5rem;

--- a/site/pool.html
+++ b/site/pool.html
@@ -10,8 +10,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .is-mono {
       font-family: monospace;

--- a/site/transaction.html
+++ b/site/transaction.html
@@ -10,8 +10,12 @@
         href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 
   <style>
+    :root {
+      color-scheme: light dark;
+    }
     body {
-      background: #f5f5f5;
+      background: var(--bulma-body-background-color, #f5f5f5);
+      color: var(--bulma-body-color, #0a0a0a);
     }
     .section {
       padding-top: 1.5rem;


### PR DESCRIPTION
## Summary
- let all pages advertise support for light and dark color schemes
- tie page backgrounds and text colors to Bulma variables so browser-level dark mode stays consistent

## Testing
- python -m http.server 8000


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931eba5530883288092d120bfd6887a)