### PR TITLE
fix: exclude master key from signers count and add Spanish translations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,19 +37,19 @@ To add a new page or view:
 ### Cache Busting & Versioning (Critical)
 The project relies on manual cache-busting via query parameters. Bump versions **only for assets you touched**; it is fine for different files to carry different version numbers.
 
-Current working version for updated assets: `12` (older untouched files may still use `7/8/9`).
+Current working version for updated assets: `13` (older untouched files may still use `7/8/9`).
 
 #### Checklist for Updates:
 1.  **If you change CSS** (e.g., `site/common.css`), bump its query in `site/index.html`:
     ```html
-    <link id="common-css" rel="stylesheet" href="/common.css?v=12">
+    <link id="common-css" rel="stylesheet" href="/common.css?v=13">
     ```
 2.  **If you change JS**:
     - Bump the import in `site/index.html` for the entry files you modified (e.g., `router.js`, `common.js`, `i18n.js`).
     - Update dynamic imports in `site/js/router.js` for view templates/scripts when you change view code, so the new versions are fetched:
       ```javascript
-      const tplRes = await fetch(`/pages/${viewName}.html?v=12`);
-      const module = await import(`./views/${viewName}.js?v=12`);
+      const tplRes = await fetch(`/pages/${viewName}.html?v=13`);
+      const module = await import(`./views/${viewName}.js?v=13`);
       ```
 3.  **If you change translations**, ensure the translation fetch in `site/js/i18n.js` points to the bumped version for those files.
 4.  Avoid blanket version bumps across untouched files; only update what you changed in the commit.

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
-  <link id="common-css" rel="stylesheet" href="/common.css?v=12">
+  <link id="common-css" rel="stylesheet" href="/common.css?v=13">
 </head>
 <body>
 
@@ -45,9 +45,9 @@
 
   <script type="module">
     // Use absolute paths to ensure they work from deep routes (e.g. /account/...)
-    import { router } from '/js/router.js?v=12';
-    import { initI18n } from '/js/i18n.js?v=12';
-    import { appVersion } from '/js/common.js?v=12';
+    import { router } from '/js/router.js?v=13';
+    import { initI18n } from '/js/i18n.js?v=13';
+    import { appVersion } from '/js/common.js?v=13';
 
     document.getElementById('app-version').textContent = appVersion;
 

--- a/site/js/common.js
+++ b/site/js/common.js
@@ -10,7 +10,7 @@ export function isLocalLike() {
 }
 
 // Статическая версия приложения, показываем в интерфейсе
-export const appVersion = '1.0.12';
+export const appVersion = '1.0.13';
 
 const base32Alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const base32Lookup = {};

--- a/site/js/i18n.js
+++ b/site/js/i18n.js
@@ -32,7 +32,7 @@ function setStoredLang(lang) {
 }
 
 function buildLangUrl(baseName, lang) {
-  return new URL(`../lang/${baseName}.${lang}.json?v=12`, import.meta.url).toString();
+  return new URL(`../lang/${baseName}.${lang}.json?v=13`, import.meta.url).toString();
 }
 
 async function fetchTranslations(baseName, lang) {

--- a/site/js/router.js
+++ b/site/js/router.js
@@ -1,4 +1,4 @@
-import { initI18n } from './i18n.js?v=12';
+import { initI18n } from './i18n.js?v=13';
 
 const routes = [
   { pattern: /^\/$/, view: 'home' },
@@ -33,13 +33,13 @@ async function loadView(route, params) {
 
     try {
         // Load Template
-        const tplRes = await fetch(`/pages/${viewName}.html?v=12`);
+        const tplRes = await fetch(`/pages/${viewName}.html?v=13`);
         if (!tplRes.ok) throw new Error(`Template ${viewName} not found`);
         const html = await tplRes.text();
         app.innerHTML = html;
 
         // Load Script
-        const module = await import(`./views/${viewName}.js?v=12`);
+        const module = await import(`./views/${viewName}.js?v=13`);
         if (module && typeof module.init === 'function') {
             currentView = module;
             // Get i18n instance from window or re-init

--- a/site/js/views/404.js
+++ b/site/js/views/404.js
@@ -9,7 +9,7 @@ export async function init(params, i18n) {
     // Let's check router.js again.
     /*
         app.innerHTML = html;
-        const module = await import(`./views/${viewName}.js?v=12`);
+        const module = await import(`./views/${viewName}.js?v=13`);
         if (module && typeof module.init === 'function') {
             currentView = module;
             const i18n = await initI18n({ baseName: viewName }); // This calls apply() inside!

--- a/site/js/views/account-offers.js
+++ b/site/js/views/account-offers.js
@@ -1,4 +1,4 @@
-import { shorten } from '/js/common.js?v=12';
+import { shorten } from '/js/common.js?v=13';
 
 const horizonBase = 'https://horizon.stellar.org';
 

--- a/site/js/views/account-operations.js
+++ b/site/js/views/account-operations.js
@@ -1,4 +1,4 @@
-import { assetLabelFull, createOperationCard } from '/js/operation-view.js?v=12';
+import { assetLabelFull, createOperationCard } from '/js/operation-view.js?v=13';
 
 const horizonBase = 'https://horizon.stellar.org';
 

--- a/site/js/views/account.js
+++ b/site/js/views/account.js
@@ -1,4 +1,4 @@
-import { shorten, isLocalLike } from '/js/common.js?v=12';
+import { shorten, isLocalLike } from '/js/common.js?v=13';
 
 const horizonBase = 'https://horizon.stellar.org';
 const poolMetaCache = new Map();
@@ -279,7 +279,7 @@ export async function init(params, i18n) {
             const detailsRows = [
                 { label: t('label-offers', 'Offers'), value: offersCount },
                 { label: t('label-trustlines', 'Trustlines'), value: trustlinesCount },
-                { label: t('label-signers', 'Signers'), value: signersCount }, // Showing total signers
+                { label: t('label-signers', 'Signers'), value: Math.max(0, signersCount - 1) },
                 { label: t('label-sponsored', 'Sponsored'), value: numSponsored },
                 { label: t('label-sponsoring', 'Sponsoring'), value: numSponsoring },
                 { label: t('label-data', 'Data'), value: dataCount },

--- a/site/js/views/asset.js
+++ b/site/js/views/asset.js
@@ -1,4 +1,4 @@
-import { shorten } from '/js/common.js?v=12';
+import { shorten } from '/js/common.js?v=13';
 
 const horizonBase = 'https://horizon.stellar.org';
 

--- a/site/js/views/contract.js
+++ b/site/js/views/contract.js
@@ -1,4 +1,4 @@
-import { shorten, strKeyToBytes, encodeAddress } from '/js/common.js?v=12';
+import { shorten, strKeyToBytes, encodeAddress } from '/js/common.js?v=13';
 
 const rpcUrl = 'https://soroban-rpc.mainnet.stellar.gateway.fm/';
 

--- a/site/js/views/home.js
+++ b/site/js/views/home.js
@@ -1,5 +1,5 @@
 
-import { shorten } from '../common.js?v=12';
+import { shorten } from '../common.js?v=13';
 
 export async function init(params, i18n) {
     const { t } = i18n;
@@ -140,17 +140,17 @@ export async function init(params, i18n) {
             saveHistory(upperVal);
             // Router handles pushState, we just navigate
             history.pushState(null, '', '/account/' + upperVal);
-            import('../router.js?v=12').then(m => m.router());
+            import('../router.js?v=13').then(m => m.router());
             return;
         }
         if (/^C[A-Z2-7]{55}$/.test(upperVal)) {
             history.pushState(null, '', '/contract/' + upperVal);
-            import('../router.js?v=12').then(m => m.router());
+            import('../router.js?v=13').then(m => m.router());
             return;
         }
         if (/^[0-9a-f]{64}$/i.test(val)) {
             history.pushState(null, '', '/tx/' + val.toLowerCase());
-            import('../router.js?v=12').then(m => m.router());
+            import('../router.js?v=13').then(m => m.router());
             return;
         }
         // Allow lowercase letters in asset code

--- a/site/js/views/offer.js
+++ b/site/js/views/offer.js
@@ -1,4 +1,4 @@
-import { shorten } from '/js/common.js?v=12';
+import { shorten } from '/js/common.js?v=13';
 
 const horizonBase = 'https://horizon.stellar.org';
 

--- a/site/js/views/operation.js
+++ b/site/js/views/operation.js
@@ -1,5 +1,5 @@
-import { shorten } from '/js/common.js?v=12';
-import { accountLink, renderOperationDetails, renderEffects } from '/js/operation-view.js?v=12'; // Ensure path is correct
+import { shorten } from '/js/common.js?v=13';
+import { accountLink, renderOperationDetails, renderEffects } from '/js/operation-view.js?v=13'; // Ensure path is correct
 
 const horizonBase = 'https://horizon.stellar.org';
 

--- a/site/js/views/pool.js
+++ b/site/js/views/pool.js
@@ -1,4 +1,4 @@
-import { shorten } from '/js/common.js?v=12';
+import { shorten } from '/js/common.js?v=13';
 
 const horizonBase = 'https://horizon.stellar.org';
 

--- a/site/js/views/transaction.js
+++ b/site/js/views/transaction.js
@@ -1,4 +1,4 @@
-import { accountLink, createXdrOperationBox, formatStroopAmount } from '/js/operation-view.js?v=12';
+import { accountLink, createXdrOperationBox, formatStroopAmount } from '/js/operation-view.js?v=13';
 
 const horizonBase = 'https://horizon.stellar.org';
 const base32Alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';

--- a/site/lang/account.es.json
+++ b/site/lang/account.es.json
@@ -48,5 +48,14 @@
   "error-load-account": "No se pudo cargar la cuenta",
   "error-unknown": "Error desconocido al cargar la cuenta.",
   "btn-estimate": "Estimar saldos",
-  "total-label": "Total"
+  "total-label": "Total",
+  "label-offers": "Ofertas",
+  "label-trustlines": "Trustlines",
+  "label-signers": "Firmantes",
+  "label-sponsored": "Patrocinado",
+  "label-sponsoring": "Patrocinando",
+  "label-data": "Datos",
+  "label-selling": "Venta",
+  "label-locked": "Total Bloqueado",
+  "label-available": "Disponible"
 }


### PR DESCRIPTION
- Updated `site/js/views/account.js` to display `signers.length - 1` (additional signers only) in the detailed breakdown, aligning with reserve logic.
- Added missing Spanish translations for new account detail labels in `site/lang/account.es.json`.
- Bumped asset versions to 13 to force cache refresh.