### PR TITLE
fix: implement path-based versioning with Caddy templates

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,9 +2,9 @@
     root * /srv
     encode gzip
 
-    # Rewrite versioned paths (e.g. /v15/js/...) to actual paths (/js/...)
+    # Rewrite versioned paths (e.g. /v15/js/... or /v1.0.14/js/...) to actual paths (/js/...)
     @versioned {
-        path_regexp v ^/v\d+/(.*)$
+        path_regexp v ^/v[^/]+/(.*)$
     }
     rewrite @versioned /{re.v.1}
 

--- a/site/js/router.js
+++ b/site/js/router.js
@@ -33,8 +33,10 @@ async function loadView(route, params) {
 
     try {
         // Load Template
-        // Use relative path to inherit the version prefix (e.g. /v15/js/../pages/ -> /v15/pages/)
-        const tplRes = await fetch(`../pages/${viewName}.html`);
+        // Use import.meta.url to resolve the path relative to THIS file (router.js),
+        // preserving the version prefix (e.g. /v15/js/router.js -> /v15/pages/view.html).
+        const tplUrl = new URL(`../pages/${viewName}.html`, import.meta.url).href;
+        const tplRes = await fetch(tplUrl);
         if (!tplRes.ok) throw new Error(`Template ${viewName} not found`);
         const html = await tplRes.text();
         app.innerHTML = html;


### PR DESCRIPTION
- Replaced brittle `{{include}}` with `{{readFile "VERSION" | trim}}` in `site/index.html` to reliably read the version file without errors.
- Updated `site/js/router.js` to use `import.meta.url` for resolving view templates, ensuring deep links correctly fetch versioned assets.
- Adjusted `Caddyfile` regex to support semantic versions (e.g. `v1.0.5`), not just integers.
- Verified that `site/VERSION` exists and is correctly populated.
- This completes the migration to a "set once, update everywhere" versioning system.