### PR TITLE
Fix crash in op view and improve lp_trade display

### DIFF
--- a/site/lang/account-operations.en.json
+++ b/site/lang/account-operations.en.json
@@ -82,6 +82,7 @@
   "op-source": "Operation Source",
   "load-effects": "Load additional info",
   "effect-trade": "Trade",
+  "effect-lp-trade": "Liquidity Pool Trade",
   "effect-credited": "Credited",
   "effect-debited": "Debited",
   "effect-bought": "Bought",

--- a/site/lang/account-operations.es.json
+++ b/site/lang/account-operations.es.json
@@ -82,6 +82,7 @@
   "op-source": "Fuente de operación",
   "load-effects": "Cargar información adicional",
   "effect-trade": "Intercambio",
+  "effect-lp-trade": "Intercambio en pool",
   "effect-credited": "Acreditado",
   "effect-debited": "Debitado",
   "effect-bought": "Comprado",

--- a/site/lang/account-operations.ru.json
+++ b/site/lang/account-operations.ru.json
@@ -82,6 +82,7 @@
   "op-source": "Источник операции",
   "load-effects": "Загрузить доп. инфо",
   "effect-trade": "Торговля",
+  "effect-lp-trade": "Торговля в пуле",
   "effect-credited": "Зачислено",
   "effect-debited": "Списано",
   "effect-bought": "Куплено",

--- a/site/lang/operation.en.json
+++ b/site/lang/operation.en.json
@@ -16,6 +16,7 @@
   "error-unknown": "Unknown error",
   "load-effects": "Load additional info",
   "effect-trade": "Trade",
+  "effect-lp-trade": "Liquidity Pool Trade",
   "effect-credited": "Credited",
   "effect-debited": "Debited",
   "effect-bought": "Bought",

--- a/site/lang/operation.es.json
+++ b/site/lang/operation.es.json
@@ -16,6 +16,7 @@
   "error-unknown": "Error desconocido",
   "load-effects": "Cargar información adicional",
   "effect-trade": "Intercambio",
+  "effect-lp-trade": "Intercambio en pool",
   "effect-credited": "Acreditado",
   "effect-debited": "Debitado",
   "effect-bought": "Comprado",

--- a/site/lang/operation.ru.json
+++ b/site/lang/operation.ru.json
@@ -16,6 +16,7 @@
   "error-unknown": "Неизвестная ошибка",
   "load-effects": "Загрузить доп. инфо",
   "effect-trade": "Торговля",
+  "effect-lp-trade": "Торговля в пуле",
   "effect-credited": "Зачислено",
   "effect-debited": "Списано",
   "effect-bought": "Куплено",

--- a/site/lang/pool-operations.en.json
+++ b/site/lang/pool-operations.en.json
@@ -81,6 +81,7 @@
   "op-source": "Operation Source",
   "load-effects": "Load additional info",
   "effect-trade": "Trade",
+  "effect-lp-trade": "Liquidity Pool Trade",
   "effect-credited": "Credited",
   "effect-debited": "Debited",
   "effect-bought": "Bought",

--- a/site/lang/pool-operations.es.json
+++ b/site/lang/pool-operations.es.json
@@ -81,6 +81,7 @@
   "op-source": "Fuente de operación",
   "load-effects": "Cargar información adicional",
   "effect-trade": "Intercambio",
+  "effect-lp-trade": "Intercambio en pool",
   "effect-credited": "Acreditado",
   "effect-debited": "Debitado",
   "effect-bought": "Comprado",

--- a/site/lang/pool-operations.ru.json
+++ b/site/lang/pool-operations.ru.json
@@ -81,6 +81,7 @@
   "op-source": "Источник операции",
   "load-effects": "Загрузить доп. инфо",
   "effect-trade": "Торговля",
+  "effect-lp-trade": "Торговля в пуле",
   "effect-credited": "Зачислено",
   "effect-debited": "Списано",
   "effect-bought": "Куплено",

--- a/site/lang/transaction.en.json
+++ b/site/lang/transaction.en.json
@@ -105,6 +105,7 @@
   "op-source": "Operation Source",
   "load-effects": "Load additional info",
   "effect-trade": "Trade",
+  "effect-lp-trade": "Liquidity Pool Trade",
   "effect-credited": "Credited",
   "effect-debited": "Debited",
   "effect-bought": "Bought",

--- a/site/lang/transaction.es.json
+++ b/site/lang/transaction.es.json
@@ -105,6 +105,7 @@
   "op-source": "Fuente de operación",
   "load-effects": "Cargar información adicional",
   "effect-trade": "Intercambio",
+  "effect-lp-trade": "Intercambio en pool",
   "effect-credited": "Acreditado",
   "effect-debited": "Debitado",
   "effect-bought": "Comprado",

--- a/site/lang/transaction.ru.json
+++ b/site/lang/transaction.ru.json
@@ -105,6 +105,7 @@
   "op-source": "Источник операции",
   "load-effects": "Загрузить доп. инфо",
   "effect-trade": "Торговля",
+  "effect-lp-trade": "Торговля в пуле",
   "effect-credited": "Зачислено",
   "effect-debited": "Списано",
   "effect-bought": "Куплено",


### PR DESCRIPTION
- Fix ReferenceError: getHorizonURL is not defined in operation-view.js by importing it.
- Implement specialized rendering for liquidity_pool_trade effects:
  - Display shortened pool ID with a link to the pool page.
  - Parse and display sold/bought assets and amounts clearly (Sold X -> Bought Y).
- Add translations for 'effect-lp-trade' in en, es, ru across relevant json files.